### PR TITLE
Convert node ids to string explizit before serialization

### DIFF
--- a/pyyed/__init__.py
+++ b/pyyed/__init__.py
@@ -173,7 +173,7 @@ class Node:
 
     def convert(self):
 
-        node = ET.Element("node", id=self.node_name)
+        node = ET.Element("node", id=str(self.node_name))
         data = ET.SubElement(node, "data", key="data_node")
         shape = ET.SubElement(data, "y:" + self.node_type)
 
@@ -238,7 +238,7 @@ class Edge:
         self.width = width
 
     def convert(self):
-        edge = ET.Element("edge", id=self.edge_id, source=self.node1, target=self.node2)
+        edge = ET.Element("edge", id=str(self.edge_id), source=str(self.node1), target=str(self.node2))
         data = ET.SubElement(edge, "data", key="data_edge")
         pl = ET.SubElement(data, "y:PolyLineEdge")
 

--- a/tests/test_pyyed.py
+++ b/tests/test_pyyed.py
@@ -85,3 +85,21 @@ def assertUmlNode(graphml, expected_stereotype, expected_attributes, expected_me
     assert umlnode.attrib['stereotype'] == expected_stereotype
     assert attributes.text == expected_attributes
     assert methods.text == expected_methods
+
+
+def test_numeric_node_ids():
+    g = pyyed.Graph()
+    g.add_node(1, label="Node1")
+    g.add_node(2, label="Node2")
+    g.add_edge(1,2)
+
+    assert g.nodes[1].label == "Node1"
+    assert g.nodes[2].label == "Node2"
+    
+    node1 = g.edges['1_2'].node1
+    node2 = g.edges['1_2'].node2
+    
+    assert g.nodes[node1].label == "Node1"
+    assert g.nodes[node2].label == "Node2"
+
+    assert g.get_graph()


### PR DESCRIPTION
- Convert node ids to string explizit before serialization to grapml in order to allow the use of numbers for node ids
- Add test for int ids

Signed-off-by: chriskn <christoph.knauf@t-online.de>